### PR TITLE
Efficient meshing

### DIFF
--- a/src/membrain_pick/mesh_conversion_cli.py
+++ b/src/membrain_pick/mesh_conversion_cli.py
@@ -107,6 +107,10 @@ def convert_single_file(
         1e4,
         help="Minimum size of the connected component. Only used if only_largest_component is True.",
     ),
+    imod_meshing: bool = Option(  # noqa: B008
+        False,
+        help="Should the mesh be generated using IMOD? WARNING: This is highly experimental.",
+    ),
 ):
     """Convert a single membrane segmentation to a mesh.
 
@@ -130,6 +134,7 @@ def convert_single_file(
         crop_box_flag=crop_box_flag,
         only_largest_component=only_largest_component,
         min_connected_size=min_connected_size,
+        imod_meshing=imod_meshing,
     )
 
 
@@ -180,6 +185,10 @@ def convert_mb_folder(
         1e4,
         help="Minimum size of the connected component. Only used if only_largest_component is True.",
     ),
+    imod_meshing: bool = Option(  # noqa: B008
+        False,
+        help="Should the mesh be generated using IMOD? WARNING: This is highly experimental.",
+    ),
 ):
     """Convert a folder of membrane segmentations to meshes.
 
@@ -201,6 +210,7 @@ def convert_mb_folder(
         crop_box_flag=crop_box_flag,
         only_largest_component=only_largest_component,
         min_connected_size=min_connected_size,
+        imod_meshing=imod_meshing,
     )
 
 
@@ -253,6 +263,10 @@ def convert_folder_structure(
         1e4,
         help="Minimum size of the connected component. Only used if only_largest_component is True.",
     ),
+    imod_meshing: bool = Option(  # noqa: B
+        False,
+        help="Should the mesh be generated using IMOD? WARNING: This is highly experimental.",
+    ),
 ):
     """Convert a folder structure of membrane segmentations to meshes.
 
@@ -274,6 +288,7 @@ def convert_folder_structure(
         crop_box_flag=crop_box_flag,
         only_largest_component=only_largest_component,
         min_connected_size=min_connected_size,
+        imod_meshing=imod_meshing,
     )
 
 

--- a/src/membrain_pick/mesh_conversion_cli.py
+++ b/src/membrain_pick/mesh_conversion_cli.py
@@ -84,8 +84,8 @@ def convert_single_file(
         help="Pixel size of the output tomogram. Only used if match_size_flag is True.",
     ),
     step_numbers: List[int] = Option(  # noqa: B008
-        (-6, 7),
-        help="Step numbers for the normal vectors. Default: (-6, 7)",
+        (-10, 10),
+        help="Step numbers for the normal vectors. Default: (-10, 10)",
     ),
     step_size: float = Option(  # noqa: B008
         2.5, help="Step size for the normal vectors. Default: 2.5"
@@ -157,8 +157,8 @@ def convert_mb_folder(
         help="Pixel size of the output tomogram. Only used if match_size_flag is True.",
     ),
     step_numbers: List[int] = Option(  # noqa: B008
-        (-6, 7),
-        help="Step numbers for the normal vectors. Default: (-6, 7)",
+        (-10, 10),
+        help="Step numbers for the normal vectors. Default: (-10, 10)",
     ),
     step_size: float = Option(  # noqa: B008
         2.5, help="Step size for the normal vectors. Default: 2.5"
@@ -230,8 +230,8 @@ def convert_folder_structure(
         help="Pixel size of the output tomogram. Only used if match_size_flag is True.",
     ),
     step_numbers: List[int] = Option(  # noqa: B008
-        (-6, 7),
-        help="Step numbers for the normal vectors. Default: (-6, 7)",
+        (-10, 10),
+        help="Step numbers for the normal vectors. Default: (-10, 10)",
     ),
     step_size: float = Option(  # noqa: B008
         2.5, help="Step size for the normal vectors. Default: 2.5"


### PR DESCRIPTION
This PR adds the functionality to use IMOD for creating meshes. However, this is highly experimental and leads to segmentation faults often. Also speedup is not drastic.

More importantly, this PR improves efficiency of mesh generation by increasing mesh decimation from 0.5 to 0.95. This way, much less vertices need to be smoothed (1. bottleneck) and subdivided into uniform triangles (2. bottleneck).
With this, mesh generation takes roughly 20-30 min for a spinach tomogram.