### PR TITLE
membrane normal orientation assignments

### DIFF
--- a/src/membrain_pick/mean_shift_inference.py
+++ b/src/membrain_pick/mean_shift_inference.py
@@ -1,33 +1,38 @@
-from membrain_pick.dataloading.data_utils import get_csv_data, store_array_in_csv, store_array_in_npy, store_point_and_vectors_in_vtp, store_array_in_star
+from membrain_pick.dataloading.data_utils import (
+    get_csv_data,
+    store_array_in_csv,
+    store_array_in_npy,
+    store_point_and_vectors_in_vtp,
+    store_array_in_star,
+)
 from membrain_pick.optimization.mean_shift_utils import MeanShiftForwarder
 from membrain_pick.mean_shift_membrainv1 import MeanShift_clustering
 import numpy as np
 import torch
 import os
+import trimesh
 from scipy.spatial import distance_matrix
+from membrain_pick.orientation import orientation_from_mesh
 
 
 def mean_shift_for_scores(
-        positions: np.ndarray,
-        scores: np.ndarray,
-        bandwidth: float,
-        max_iter: int,
-        margin: float,
-        device: str,
-        score_threshold: float = 9.0,
+    positions: np.ndarray,
+    scores: np.ndarray,
+    bandwidth: float,
+    max_iter: int,
+    margin: float,
+    device: str,
+    score_threshold: float = 9.0,
 ):
-    
 
     # ms_forwarder = MeanShift_clustering(pos_thres=score_threshold)
     # clusters, cluster_labels = ms_forwarder.cluster_NN_output(positions, scores, bandwidth=bandwidth)
     # return clusters, cluster_labels
 
-    ms_forwarder = MeanShiftForwarder(bandwidth=bandwidth,
-                                  max_iter=max_iter,
-                                  device=device,
-                                  margin=margin)
-    
-    
+    ms_forwarder = MeanShiftForwarder(
+        bandwidth=bandwidth, max_iter=max_iter, device=device, margin=margin
+    )
+
     positions = torch.from_numpy(positions).to(device)
     scores = torch.from_numpy(scores).to(device)
     mask = scores < score_threshold
@@ -41,27 +46,32 @@ def mean_shift_for_scores(
 
     return out_pos, out_p_num
 
+
 def mean_shift_for_csv(
-        csv_file: str,
-        out_dir: str,
-        bandwidth: float,
-        max_iter: int,
-        margin: float,
-        device: str,
-        score_threshold: float = 9.0,
+    csv_file: str,
+    out_dir: str,
+    bandwidth: float,
+    max_iter: int,
+    margin: float,
+    device: str,
+    score_threshold: float = 9.0,
 ):
     csv_data = np.array(get_csv_data(csv_file), dtype=float)
     positions = csv_data[:, :3]
     scores = csv_data[:, 3]
-    out_pos, out_p_num = mean_shift_for_scores(positions, scores, bandwidth, max_iter, margin, device, score_threshold)
+    out_pos, out_p_num = mean_shift_for_scores(
+        positions, scores, bandwidth, max_iter, margin, device, score_threshold
+    )
     store_clusters(csv_file, out_dir, out_pos, out_p_num)
 
 
 def store_clusters(
-        csv_file: str,
-        out_dir: str,
-        out_pos: np.ndarray,
-        out_p_num: np.ndarray,
+    csv_file: str,
+    out_dir: str,
+    out_pos: np.ndarray,
+    out_p_num: np.ndarray,
+    verts: np.ndarray = None,
+    faces: np.ndarray = None,
 ):
     os.makedirs(out_dir, exist_ok=True)
     # store_array_in_csv(
@@ -78,8 +88,21 @@ def store_clusters(
     #     in_scalars=[out_p_num, np.arange(out_pos.shape[0])],
     # )
     print(out_pos.shape, "clusters found")
+    print(verts.shape, faces.shape, "<-----")
+    mesh = trimesh.Trimesh(vertices=verts, faces=faces)
+    relion_euler_angles = orientation_from_mesh(out_pos, mesh)
+    out_pos = np.concatenate([out_pos, relion_euler_angles], axis=1)
     store_array_in_star(
-        out_file=os.path.join(out_dir, os.path.basename(csv_file).replace('.csv', '_clusters.star')),
+        out_file=os.path.join(
+            out_dir, os.path.basename(csv_file).replace(".csv", "_clusters.star")
+        ),
         data=out_pos,
-        header=["rlnCoordinateX", "rlnCoordinateY", "rlnCoordinateZ"]
+        header=[
+            "rlnCoordinateX",
+            "rlnCoordinateY",
+            "rlnCoordinateZ",
+            "rlnAngleRot",
+            "rlnAngleTilt",
+            "rlnAnglePsi",
+        ],
     )

--- a/src/membrain_pick/mesh_conversion_cli.py
+++ b/src/membrain_pick/mesh_conversion_cli.py
@@ -603,6 +603,45 @@ def surforama(
     napari.run()
 
 
+@cli.command(name="assign_angles", no_args_is_help=True)
+def assign_angles(
+    position_file: str = Option(  # noqa: B008
+        ...,
+        help="Path to the positions file. Can be a CSV file (first 3 columns are x, y, z) or a star file (relion or stopgap).",
+        **PKWARGS,
+    ),
+    obj_file: str = Option(  # noqa: B008
+        default="",
+        help="Path to an obj file with the membrane mesh. Provide either this or the segmentation file.",
+    ),
+    segmentation_file: str = Option(  # noqa: B008
+        default="",
+        help="Path to a membrane segmentation file. Provide either this or the obj file.",
+    ),
+    out_dir: str = Option(  # noqa: B008
+        "./angle_output",
+        help="Path to the folder where the output should be stored.",
+    ),
+    position_scale_factor: float = Option(
+        1.0, help="Rescale points to match mesh dimensions"
+    ),  # noqa: B008
+    out_format: str = Option(  # noqa: B008
+        "RELION",
+        help="Output format for the angles. Choose from RELION or STOPGAP.",
+    ),
+):
+    from membrain_pick.orientation import orientation_from_files
+
+    orientation_from_files(
+        positions_file=position_file,
+        out_dir=out_dir,
+        mesh_file=obj_file if len(obj_file) > 0 else None,
+        segmentation_file=segmentation_file if len(segmentation_file) > 0 else None,
+        positions_scale_factor=position_scale_factor,
+        out_format=out_format,
+    )
+
+
 @cli.command(name="tomotwin_extract", no_args_is_help=True)
 def tomotwin_extract(
     h5_path: str = Option(  # noqa: B008

--- a/src/membrain_pick/orientation.py
+++ b/src/membrain_pick/orientation.py
@@ -1,0 +1,247 @@
+import os
+import numpy as np
+import scipy.spatial as spatial
+import trimesh
+from surforama.utils.geometry import rotate_around_vector
+from scipy.spatial.transform import Rotation as R
+from membrain_pick.dataloading.data_utils import (
+    get_csv_data,
+    read_star_file,
+    store_array_in_csv,
+    store_array_in_star,
+)
+from membrain_pick.compute_mesh_projection import convert_seg_to_mesh
+from membrain_seg.segmentation.dataloading.data_utils import load_tomogram
+
+
+def orientation_from_mesh(coordinates, mesh):
+    """
+    Get the orientation of a point cloud from a mesh.
+
+    This is taken in large parts from the Surforama codebase.
+
+    Parameters
+    ----------
+    coordinates : np.ndarray
+        The coordinates of the point cloud.
+    mesh : trimesh.Trimesh
+        The mesh.
+    maximum_distance : float, optional
+        The maximum distance to consider. Default is None.
+
+    Returns
+    -------
+    np.ndarray
+        The orientations of the point cloud.
+    """
+    # get the closest vertices
+    tree = spatial.cKDTree(mesh.vertices)
+    distances, vertex_indices = tree.query(coordinates)
+
+    if np.any(distances > 200):
+        print(
+            "Warning: Some points are more than 200 units away from the mesh. This might be an error. Check rescaling factors."
+        )
+
+    mesh.vertices = mesh.vertices[:, ::-1]
+
+    # get the normals of the closest vertices
+    normals = mesh.vertex_normals[vertex_indices]
+    # normalize the normals
+    normals /= np.linalg.norm(normals, axis=1)[:, None]
+
+    # get perpendicular vectors
+    up_vectors = np.cross(normals, np.array([0, 0, 1]))
+    up_vectors /= np.linalg.norm(up_vectors, axis=1)[:, None]
+
+    # draw a random angle between 0 and 360
+    random_angle = np.random.uniform(0, 10)
+    random_angle = np.zeros_like(random_angle)
+
+    # rotate the up vectors around the normals
+    up_vectors = rotate_around_vector(
+        rotate_around=normals,
+        to_rotate=up_vectors,
+        angle=random_angle,
+    )
+
+    third_basis = np.cross(normals, up_vectors)
+    n_points = len(coordinates)
+    particle_orientations = np.zeros((n_points, 3, 3))
+    particle_orientations[:, :, 0] = third_basis[:, ::-1]
+    particle_orientations[:, :, 1] = up_vectors[:, ::-1]
+    particle_orientations[:, :, 2] = normals[:, ::-1]
+
+    euler_angles = (
+        R.from_matrix(particle_orientations).inv().as_euler(seq="ZYZ", degrees=True)
+    )  # This gives Euler angles in Relion format: Rot, Tilt, Psi
+    return euler_angles
+
+
+def convert_relion_to_stopgap(relion_angles):
+    """
+    Convert Euler angles from Relion format to Stopgap format.
+
+    Parameters
+    ----------
+    relion_angles : np.ndarray
+        The Euler angles in Relion format.
+
+    Returns
+    -------
+    np.ndarray
+        The Euler angles in Stopgap format.
+    """
+
+    # relion angles are ZYZ: Rot, Tilt, Psi
+    # stopgap angles are ZXZ: Phi, Theta, Psi
+
+    rot = relion_angles[:, 0]
+    tilt = relion_angles[:, 1]
+    psi = relion_angles[:, 2]
+
+    phi = -rot - 90
+    theta = -tilt
+    psi = -psi + 90
+
+    return np.stack([phi, theta, psi], axis=1)
+
+
+def read_positions(positions_file):
+    """
+    Read positions from a file.
+
+    Parameters
+    ----------
+    positions_file : str
+        The path to the positions file.
+
+    Returns
+    -------
+    np.ndarray
+        The positions.
+    """
+    if positions_file.endswith(".csv"):
+        return get_csv_data(positions_file)[:, :3]
+    elif positions_file.endswith(".star"):
+        star_data = read_star_file(positions_file)
+        if "rlnCoordinateX" in star_data:
+            return np.stack(
+                [
+                    star_data["rlnCoordinateX"],
+                    star_data["rlnCoordinateY"],
+                    star_data["rlnCoordinateZ"],
+                ],
+                axis=1,
+            )
+        elif "orig_x" in star_data:
+            return np.stack(
+                [
+                    star_data["orig_x"],
+                    star_data["orig_y"],
+                    star_data["orig_z"],
+                ],
+                axis=1,
+            )
+
+
+def _store_array(in_file: str, out_dir: str, data: np.ndarray, out_format: str):
+    """
+    Store an array in a file.
+
+    Parameters
+    ----------
+    in_file : str
+        The input file.
+    out_file : str
+        The output file.
+    data : np.ndarray
+        The data to store.
+    out_format : str
+        The output format.
+    """
+    os.makedirs(out_dir, exist_ok=True)
+    if in_file.endswith(".csv"):
+        out_file = os.path.join(
+            out_dir, os.path.basename(in_file).replace(".csv", "_withOrientation.star")
+        )
+        store_array_in_csv(out_file, data)
+    elif in_file.endswith(".star"):
+        out_file = os.path.join(
+            out_dir, os.path.basename(in_file).replace(".star", "_withOrientation.star")
+        )
+        if out_format == "RELION":
+            header = [
+                "rlnCoordinateX",
+                "rlnCoordinateY",
+                "rlnCoordinateZ",
+                "rlnAngleRot",
+                "rlnAngleTilt",
+                "rlnAnglePsi",
+            ]
+        elif out_format == "STOPGAP":
+            header = [
+                "orig_x",
+                "orig_y",
+                "orig_z",
+                "phi",
+                "theta",
+                "psi",
+            ]
+        store_array_in_star(out_file, data, header=header)
+
+
+def orientation_from_files(
+    positions_file: str,
+    out_dir: str,
+    mesh_file: str = None,
+    segmentation_file: str = None,
+    positions_scale_factor: float = 1.0,
+    out_format: str = "RELION",
+):
+    """
+    Get the orientation of a point cloud from a mesh.
+
+    Parameters
+    ----------
+    positions_file : str
+        The path to the positions file.
+    out_dir : str
+        The output directory.
+    mesh_file : str, optional
+        The path to the mesh file. Default is None.
+    segmentation_file : str, optional
+        The path to the segmentation file. Default is None.
+    maximum_distance : float, optional
+        The maximum distance to consider. Default is None.
+    positions_scale_factor : float, optional
+        The scale factor for the positions. Default is 1.0.
+    out_format : str, optional
+        The output format. Default is "RELION".
+    """
+    positions = read_positions(positions_file)
+    if positions_scale_factor != 1.0:
+        positions *= positions_scale_factor
+
+    if mesh_file is not None:
+        mesh = trimesh.load_mesh(mesh_file)
+    elif segmentation_file is not None:
+        segmentation = load_tomogram(segmentation_file).data
+        mesh = convert_seg_to_mesh(segmentation, smoothing=1000)
+        # convert from pyvista to trimesh
+        verts = mesh.points
+        faces = mesh.faces
+        faces = faces.reshape(-1, 4)[:, 1:]
+        mesh = trimesh.Trimesh(vertices=verts, faces=faces)
+    orientations = orientation_from_mesh(positions, mesh)
+    if out_format == "RELION":
+        orientations = convert_relion_to_stopgap(orientations)
+
+    positions = np.concatenate([positions, orientations], axis=1)
+
+    _store_array(
+        in_file=positions_file,
+        out_dir=out_dir,
+        data=positions,
+        out_format=out_format,
+    )

--- a/src/membrain_pick/predict.py
+++ b/src/membrain_pick/predict.py
@@ -241,6 +241,8 @@ def predict(
                     out_dir=out_dir,
                     out_pos=clusters,
                     out_p_num=out_p_num,
+                    verts=unique_verts,
+                    faces=new_faces,
                 )
             save_output_h5(
                 unique_verts,
@@ -295,6 +297,8 @@ def predict(
             out_dir=out_dir,
             out_pos=clusters,
             out_p_num=out_p_num,
+            verts=unique_verts,
+            faces=new_faces,
         )
     save_output_h5(
         unique_verts,


### PR DESCRIPTION
This adds functionality to assign membrane normal orientations to positions. 
This is now done automatically in the predict.py function into the output .star files

Also, this function is available as a standalone, reading star / csv files together with membrane meshes / segmentations, and assigning orientations, and outputting star files with orientation (relion / stopgap format)